### PR TITLE
Fix issue on sample code - require usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ s3cmd: [s3-cli](https://github.com/andrewrk/node-s3-cli).
 ### Create a client
 
 ```js
-var s3 = require('s3');
+var s3 = require('@auth0/s3');
 
 var client = s3.createClient({
   maxAsyncS3: 20,     // this is the default
@@ -52,7 +52,7 @@ var client = s3.createClient({
 ### Create a client from existing AWS.S3 object
 
 ```js
-var s3 = require('s3');
+var s3 = require('@auth0/s3');
 var awsS3Client = new AWS.S3(s3Options);
 var options = {
   s3Client: awsS3Client,
@@ -618,7 +618,7 @@ Using the AWS SDK, you can send a HEAD request, which will tell you if a file ex
 See http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#headObject-property
 
 ```js
-var client = require('s3').createClient({ /* options */ });
+var client = require('@auth0/s3').createClient({ /* options */ });
 client.s3.headObject({
   Bucket: 's3 bucket name',
   Key: 'some/remote/file'


### PR DESCRIPTION
### Description

Code samples should use `require('@auth0/s3')`

### Testing

This came up the moment I used the lib on one of my projects, so it should be pretty straightforward to test... just use the lib ;)

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`