### PR TITLE
fix: Do not check ETag for SSE KMS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,7 @@ Client.prototype.uploadFile = function(params) {
     var defaultContentType = params.defaultContentType || 'application/octet-stream';
     s3Params.ContentType = mime.getType(localFile, defaultContentType);
   }
+  var sse = s3Params.ServerSideEncryption;
   var fatalError = false;
   var localFileSlicer = null;
   var parts = [];
@@ -315,7 +316,7 @@ Client.prototype.uploadFile = function(params) {
           }
           pend.wait(function() {
             if (fatalError) return;
-            if (!compareMultipartETag(data.ETag, multipartETag)) {
+            if (sse !== 'aws:kms' && !compareMultipartETag(data.ETag, multipartETag)) {
               errorOccurred = true;
               uploader.progressAmount -= overallDelta;
               cb(new Error("ETag does not match MD5 checksum"));
@@ -411,7 +412,7 @@ Client.prototype.uploadFile = function(params) {
         }
         pend.wait(function() {
           if (fatalError) return;
-          if (!compareMultipartETag(data.ETag, localFileStat.multipartETag)) {
+          if (sse !== 'aws:kms' && !compareMultipartETag(data.ETag, localFileStat.multipartETag)) {
             cb(new Error("ETag does not match MD5 checksum"));
             return;
           }
@@ -507,9 +508,11 @@ Client.prototype.downloadFile = function(params) {
               handleError(new Error("Downloaded size does not match Content-Length"));
               return;
             }
-            if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
-              handleError(new Error("ETag does not match MD5 checksum"));
-              return;
+            if (headers['x-amz-server-side-encryption'] !== 'aws:kms' ) {
+              if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
+                handleError(new Error("ETag does not match MD5 checksum"));
+                return;
+              }
             }
             cb();
           });
@@ -773,6 +776,7 @@ Client.prototype.downloadBuffer = function(s3Params) {
   var self = this;
   var downloader = new EventEmitter();
   s3Params = extend({}, s3Params);
+  var sse = s3Params.ServerSideEncryption;
 
   downloader.progressAmount = 0;
 
@@ -825,9 +829,11 @@ Client.prototype.downloadBuffer = function(s3Params) {
             handleError(new Error("Downloaded size does not match Content-Length"));
             return;
           }
-          if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
-            handleError(new Error("ETag does not match MD5 checksum"));
-            return;
+          if (headers['x-amz-server-side-encryption'] !== 'aws:kms' ) {
+            if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
+              handleError(new Error("ETag does not match MD5 checksum"));
+              return;
+            }
           }
           cb();
         });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Currently any sync operation with a bucket that has encryption turned on fails the etag check. 
```
Error: ETag does not match MD5 checksum
```


### References


https://github.com/andrewrk/node-s3-client/pull/166/
https://github.com/k1LoW/serverless-s3-sync/issues/23


### Testing

N/A

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
