### PR TITLE
Fix default mime type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,7 @@ Client.prototype.uploadFile = function(params) {
   var s3Params = extend({}, params.s3Params);
   if (s3Params.ContentType === undefined) {
     var defaultContentType = params.defaultContentType || 'application/octet-stream';
-    s3Params.ContentType = mime.getType(localFile, defaultContentType);
+    s3Params.ContentType = mime.getType(localFile) || defaultContentType;
   }
   var fatalError = false;
   var localFileSlicer = null;


### PR DESCRIPTION
I ran into an issue where the `defaultContentType` params was not being used. The root cause is `mime.getType(...)` does not use the second argument as a fallback like the legacy `mime.lookup(...)` did.